### PR TITLE
Add UnorderedDeepEq and UnorderedNoDiff matchers.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,9 @@ linters:
     - wsl
     - gofumpt
     - exhaustive
+    - exhaustivestruct
+    - paralleltest
+    - wrapcheck
 issues:
   exclude-rules:
     - path: _test\.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ go:
 - 1.x
 - 1.15.x
 before_install:
-- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.31.0
+- curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
 - go get golang.org/x/tools/cmd/cover
 - go get github.com/mattn/goveralls
 script:

--- a/assertion/slice_exp.go
+++ b/assertion/slice_exp.go
@@ -1,5 +1,11 @@
 package assertion
 
+import (
+	"reflect"
+
+	"github.com/elethoughts-code/goasserts/diff"
+)
+
 // SliceExpectation interface encloses slice related expectations.
 //
 // Contains(e interface{}) check if e parameter is into the slice.
@@ -15,6 +21,8 @@ package assertion
 type SliceExpectation interface {
 	Contains(e interface{})
 	Unordered(e interface{})
+	UnorderedDeepEq(e interface{})
+	UnorderedNoDiff(e interface{})
 	All(m Matcher)
 	AtLeast(n int, m Matcher)
 	Any(m Matcher)
@@ -27,7 +35,22 @@ func (exp *expectation) Contains(e interface{}) {
 
 func (exp *expectation) Unordered(e interface{}) {
 	exp.t.Helper()
-	exp.Matches(Unordered(e))
+	exp.Matches(Unordered(e, func(v, e interface{}) bool {
+		return v == e
+	}))
+}
+
+func (exp *expectation) UnorderedDeepEq(e interface{}) {
+	exp.t.Helper()
+	exp.Matches(Unordered(e, reflect.DeepEqual))
+}
+
+func (exp *expectation) UnorderedNoDiff(e interface{}) {
+	exp.t.Helper()
+	exp.Matches(Unordered(e, func(v, e interface{}) bool {
+		diffs := diff.Diffs(v, e)
+		return len(diffs) == 0
+	}))
 }
 
 func (exp *expectation) All(m Matcher) {

--- a/assertion/slice_exp_test.go
+++ b/assertion/slice_exp_test.go
@@ -43,6 +43,42 @@ func Test_Unordered_should_pass(t *testing.T) {
 	// Then nothing
 }
 
+func Test_UnorderedDeepEq_should_pass(t *testing.T) {
+	// Given
+	assert := assertion.New(t)
+
+	// When
+	assert.That(nil).Unordered(nil)
+
+	assert.That([]string{"a", "b", "c"}).UnorderedDeepEq([]string{"a", "b", "c"})
+	assert.That([]string{"a", "b", "c"}).UnorderedDeepEq([]string{"b", "a", "c"})
+	assert.That([]string{"a", "b", "c"}).UnorderedDeepEq([]string{"c", "a", "b"})
+
+	assert.That([]string{"a", "b", "c"}).Not().UnorderedDeepEq([]string{"a", "b"})
+	assert.That([]string{"a", "b", "c"}).Not().UnorderedDeepEq([]string{"b", "a", "c", "d"})
+	assert.That([]string{"a", "b", "c"}).Not().UnorderedDeepEq([]int{1, 2, 3})
+
+	// Then nothing
+}
+
+func Test_UnorderedNoDiff_should_pass(t *testing.T) {
+	// Given
+	assert := assertion.New(t)
+
+	// When
+	assert.That(nil).Unordered(nil)
+
+	assert.That([]string{"a", "b", "c"}).UnorderedNoDiff([]string{"a", "b", "c"})
+	assert.That([]string{"a", "b", "c"}).UnorderedNoDiff([]string{"b", "a", "c"})
+	assert.That([]string{"a", "b", "c"}).UnorderedNoDiff([]string{"c", "a", "b"})
+
+	assert.That([]string{"a", "b", "c"}).Not().UnorderedNoDiff([]string{"a", "b"})
+	assert.That([]string{"a", "b", "c"}).Not().UnorderedNoDiff([]string{"b", "a", "c", "d"})
+	assert.That([]string{"a", "b", "c"}).Not().UnorderedNoDiff([]int{1, 2, 3})
+
+	// Then nothing
+}
+
 func Test_All_should_pass(t *testing.T) {
 	// Given
 	assert := assertion.New(t)
@@ -136,6 +172,14 @@ func Test_Slice_Matchers_should_fail(t *testing.T) {
 		},
 		{
 			assertFunc: func(assert assertion.Assert) { assert.That([]string{}).Unordered([]string{"b"}) },
+			errLog:     fmt.Sprintf("\nValue should contains all elements : %v", []string{"b"}),
+		},
+		{
+			assertFunc: func(assert assertion.Assert) { assert.That([]string{}).UnorderedDeepEq([]string{"b"}) },
+			errLog:     fmt.Sprintf("\nValue should contains all elements : %v", []string{"b"}),
+		},
+		{
+			assertFunc: func(assert assertion.Assert) { assert.That([]string{}).UnorderedNoDiff([]string{"b"}) },
 			errLog:     fmt.Sprintf("\nValue should contains all elements : %v", []string{"b"}),
 		},
 		{

--- a/assertion/slice_matchers.go
+++ b/assertion/slice_matchers.go
@@ -38,7 +38,7 @@ func Contains(e interface{}) Matcher {
 	}
 }
 
-func Unordered(e interface{}) Matcher {
+func Unordered(e interface{}, areEq func(v, e interface{}) bool) Matcher {
 	return func(v interface{}) (MatchResult, error) {
 		iv, isSlice := toSlice(v)
 		if !isSlice {
@@ -56,7 +56,7 @@ func Unordered(e interface{}) Matcher {
 		for _, expectedItem := range ie {
 			found := false
 			for _, sliceItem := range iv {
-				if sliceItem == expectedItem {
+				if areEq(sliceItem, expectedItem) {
 					found = true
 					break
 				}


### PR DESCRIPTION
Update golangci-linter.
Closes #14