### PR TITLE
Add Filesystem utilities and assertions (This closes #16) :

### DIFF
--- a/assertion/assert.go
+++ b/assertion/assert.go
@@ -41,9 +41,12 @@ type Expectation interface {
 	StringExpectation
 	SliceExpectation
 	MapExpectation
+	FsExpectation
 	MapTransformer
+	FsTransformer
 	AttributeParser
 	HTTPRecorderParser
+	ReflectTransformer
 }
 
 type assert struct {

--- a/assertion/fs_exp.go
+++ b/assertion/fs_exp.go
@@ -1,0 +1,10 @@
+package assertion
+
+type FsExpectation interface {
+	FileExists()
+}
+
+func (exp *expectation) FileExists() {
+	exp.t.Helper()
+	exp.Matches(FileExists())
+}

--- a/assertion/fs_exp_test.go
+++ b/assertion/fs_exp_test.go
@@ -1,0 +1,82 @@
+package assertion_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elethoughts-code/goasserts/assertion"
+	fsBuilder "github.com/elethoughts-code/goasserts/fs_builder"
+	mocks "github.com/elethoughts-code/goasserts/mocks/assertion"
+	"github.com/golang/mock/gomock"
+)
+
+func Test_File_exists_should_check_file_existence(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+
+	file4 := tmpFolder.Dir("my_sub_folder", 0600).
+		File("file_1", os.O_CREATE, 0600).Parent().
+		File("file_2", os.O_CREATE, 0600).Parent().
+		File("file_3", os.O_CREATE, 0600).Root().
+		File("file_4", os.O_CREATE, 0600)
+
+	// Then
+
+	assert.That(filepath.Join(tmpFolder.Name(), "my_sub_folder")).FileExists()
+	assert.That(filepath.Join(tmpFolder.Name(), "my_sub_folder", "file_1")).FileExists()
+	assert.That(filepath.Join(tmpFolder.Name(), "my_sub_folder", "file_2")).FileExists()
+	assert.That(filepath.Join(tmpFolder.Name(), "my_sub_folder", "file_3")).FileExists()
+	assert.That(filepath.Join(tmpFolder.Name(), "file_4")).FileExists()
+
+	// When
+	file4.Remove()
+
+	// Then
+	assert.That(filepath.Join(tmpFolder.Name(), "file_4")).Not().FileExists()
+
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+func Test_Fs_Matchers_should_fail(t *testing.T) {
+	// Mock preparation
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+
+	testEntries := []struct {
+		assertFunc func(assert assertion.Assert)
+		errLog     string
+	}{
+		{
+			assertFunc: func(assert assertion.Assert) {
+				assert.That("/my_file").FileExists()
+			},
+			errLog: "\nFile /my_file do not exists",
+		},
+		{
+			assertFunc: func(assert assertion.Assert) {
+				assert.That(tmpFolder.Name()).Not().FileExists()
+			},
+			errLog: fmt.Sprintf("\nFile %s should not exists", tmpFolder.Name()),
+		},
+	}
+
+	for _, entry := range testEntries {
+		// Given
+		tMock := mocks.NewMockPublicTB(ctrl)
+		assert := assertion.New(tMock)
+
+		// Expectation
+		tMock.EXPECT().Helper().AnyTimes()
+		tMock.EXPECT().Error(entry.errLog)
+
+		// When
+		entry.assertFunc(assert)
+	}
+}

--- a/assertion/fs_matchers.go
+++ b/assertion/fs_matchers.go
@@ -1,0 +1,15 @@
+package assertion
+
+import (
+	"fmt"
+	"os"
+)
+
+func FileExists() Matcher {
+	return func(v interface{}) (MatchResult, error) {
+		if _, err := os.Stat(v.(string)); !os.IsNotExist(err) {
+			return truthy(fmt.Sprintf("\nFile %v should not exists", v))
+		}
+		return falsy(fmt.Sprintf("\nFile %v do not exists", v))
+	}
+}

--- a/assertion/fs_transf.go
+++ b/assertion/fs_transf.go
@@ -1,0 +1,55 @@
+package assertion
+
+import (
+	"encoding/json"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+type FsTransformer interface {
+	FileAsString() Expectation
+	FileAsJSON(content interface{}) Expectation
+	FileAsYAML(content interface{}) Expectation
+}
+
+func (exp *expectation) FileAsString() Expectation {
+	exp.t.Helper()
+	content, err := ioutil.ReadFile(exp.v.(string))
+	if err != nil {
+		panic(err)
+	}
+	exp.v = string(content)
+	return exp
+}
+
+func (exp *expectation) decode(decoder func(b []byte) (interface{}, error)) Expectation {
+	exp.t.Helper()
+	b, err := ioutil.ReadFile(exp.v.(string))
+	if err != nil {
+		panic(err)
+	}
+
+	decoded, err := decoder(b)
+	if err != nil {
+		panic(err)
+	}
+	exp.v = decoded
+	return exp
+}
+
+func (exp *expectation) FileAsJSON(content interface{}) Expectation {
+	exp.t.Helper()
+	return exp.decode(func(b []byte) (interface{}, error) {
+		err := json.Unmarshal(b, content)
+		return content, err
+	})
+}
+
+func (exp *expectation) FileAsYAML(content interface{}) Expectation {
+	exp.t.Helper()
+	return exp.decode(func(b []byte) (interface{}, error) {
+		err := yaml.Unmarshal(b, content)
+		return content, err
+	})
+}

--- a/assertion/fs_transf_test.go
+++ b/assertion/fs_transf_test.go
@@ -1,0 +1,139 @@
+package assertion_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/elethoughts-code/goasserts/assertion"
+	fsBuilder "github.com/elethoughts-code/goasserts/fs_builder"
+)
+
+func Test_should_read_file_into_string(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+
+	file := tmpFolder.File("file", os.O_CREATE, 0600).WriteString("hello world")
+
+	// Then
+	assert.That(file.Name()).FileAsString().IsEq("hello world")
+
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+type sampleStruct struct {
+	Value1 string   `json:"value1" yaml:"value1"`
+	Value2 int      `json:"value2" yaml:"value2"`
+	Value3 []string `json:"value3" yaml:"value3"`
+}
+
+func Test_should_read_file_into_struct_as_JSON(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+
+	file := tmpFolder.File("file", os.O_CREATE, 0600).WriteString(`
+		{
+			"value1": "hello world",
+			"value2": 10,
+			"value3": ["a", "b", "c"]
+		}
+	`)
+
+	// Then
+	assert.That(file.Name()).FileAsJSON(&sampleStruct{}).Dereference().IsDeepEq(sampleStruct{
+		Value1: "hello world",
+		Value2: 10,
+		Value3: []string{"a", "b", "c"},
+	})
+
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+func Test_should_read_file_into_struct_as_YAML(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+
+	file := tmpFolder.File("file", os.O_CREATE, 0600).WriteStringDedent(`
+			value1: hello world
+			value2: 10
+			value3:
+			  - a
+			  - b
+			  - c`)
+
+	// Then
+	assert.That(file.Name()).FileAsYAML(&sampleStruct{}).Dereference().IsDeepEq(sampleStruct{
+		Value1: "hello world",
+		Value2: 10,
+		Value3: []string{"a", "b", "c"},
+	})
+
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+func Test_should_panic_when_reading_file_as_string_and_dont_exists(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+
+	assert.That("/file").FileAsString()
+}
+
+func Test_should_panic_when_reading_file_as_json_and_dont_exists(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+
+	assert.That("/file").FileAsJSON([]string{})
+}
+
+func Test_should_panic_when_reading_file_as_yaml_and_dont_exists(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+
+	assert.That("/file").FileAsYAML([]string{})
+}
+
+func Test_should_panic_when_reading_file_as_yaml_and_syntax_error(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r.(error).Error()).HasPrefix("yaml: line")
+	}()
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+
+	file := tmpFolder.File("file", os.O_CREATE, 0600).WriteStringDedent(`
+			value1: hello world
+			value2: 10
+			value3:
+			  - a
+			  - b
+			- c`)
+
+	// Then
+	assert.That(file.Name()).FileAsYAML(&sampleStruct{}).Dereference().IsDeepEq(sampleStruct{
+		Value1: "hello world",
+		Value2: 10,
+		Value3: []string{"a", "b", "c"},
+	})
+
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}

--- a/assertion/reflect_transf.go
+++ b/assertion/reflect_transf.go
@@ -1,0 +1,21 @@
+package assertion
+
+import (
+	"reflect"
+)
+
+type ReflectTransformer interface {
+	Dereference() Expectation
+}
+
+func (exp *expectation) Dereference() Expectation {
+	exp.t.Helper()
+	v := reflect.ValueOf(exp.v)
+	switch v.Kind() {
+	case reflect.Ptr:
+		exp.v = v.Elem().Interface()
+	default:
+		panic("value is not a pointer")
+	}
+	return exp
+}

--- a/assertion/reflect_transf_test.go
+++ b/assertion/reflect_transf_test.go
@@ -1,0 +1,40 @@
+package assertion_test
+
+import (
+	"testing"
+
+	"github.com/elethoughts-code/goasserts/assertion"
+)
+
+type sample struct {
+	a string
+	b int
+}
+
+func Test_should_dereference_pointer(t *testing.T) {
+	assert := assertion.New(t)
+	// Then
+	assert.That(&sample{
+		a: "hello world",
+		b: 10,
+	}).Dereference().IsEq(sample{
+		a: "hello world",
+		b: 10,
+	})
+}
+
+func Test_should_panic_when_non_pointer_value_is_de_referenced(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsEq("value is not a pointer")
+	}()
+
+	assert.That(sample{
+		a: "hello world",
+		b: 10,
+	}).Dereference().IsEq(sample{
+		a: "hello world",
+		b: 10,
+	})
+}

--- a/assertion/str_exp.go
+++ b/assertion/str_exp.go
@@ -8,6 +8,8 @@ package assertion
 type StringExpectation interface {
 	IsBlank()
 	MatchRe(reg string)
+	HasPrefix(prefix string)
+	HasSuffix(suffix string)
 }
 
 func (exp *expectation) IsBlank() {
@@ -18,4 +20,14 @@ func (exp *expectation) IsBlank() {
 func (exp *expectation) MatchRe(reg string) {
 	exp.t.Helper()
 	exp.Matches(MatchRe(reg))
+}
+
+func (exp *expectation) HasPrefix(prefix string) {
+	exp.t.Helper()
+	exp.Matches(HasPrefix(prefix))
+}
+
+func (exp *expectation) HasSuffix(suffix string) {
+	exp.t.Helper()
+	exp.Matches(HasSuffix(suffix))
 }

--- a/assertion/str_exp_test.go
+++ b/assertion/str_exp_test.go
@@ -40,6 +40,30 @@ func Test_MatchRe_should_pass(t *testing.T) {
 	// Then nothing
 }
 
+func Test_HasPrefix_should_pass(t *testing.T) {
+	// Given
+	assert := assertion.New(t)
+
+	// When
+
+	assert.That("123456").HasPrefix("123")
+	assert.That("123456a").Not().HasPrefix("23")
+
+	// Then nothing
+}
+
+func Test_HasSuffix_should_pass(t *testing.T) {
+	// Given
+	assert := assertion.New(t)
+
+	// When
+
+	assert.That("123456").HasSuffix("456")
+	assert.That("123456a").Not().HasSuffix("23")
+
+	// Then nothing
+}
+
 func Test_String_Matchers_should_fail(t *testing.T) {
 	// Mock preparation
 	ctrl := gomock.NewController(t)

--- a/assertion/str_matchers.go
+++ b/assertion/str_matchers.go
@@ -3,6 +3,7 @@ package assertion
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 func IsBlank() Matcher {
@@ -28,5 +29,23 @@ func MatchRe(reg string) Matcher {
 			return truthy(fmt.Sprintf("\nValue should not match regexp : %s", reg))
 		}
 		return falsy(fmt.Sprintf("\nValue do not match regexp : %s", reg))
+	}
+}
+
+func HasPrefix(prefix string) Matcher {
+	return func(v interface{}) (MatchResult, error) {
+		if strings.HasPrefix(v.(string), prefix) {
+			return truthy(fmt.Sprintf("\nValue should have prefix = %s", prefix))
+		}
+		return falsy(fmt.Sprintf("\nValue should not have prefix = %s", prefix))
+	}
+}
+
+func HasSuffix(suffix string) Matcher {
+	return func(v interface{}) (MatchResult, error) {
+		if strings.HasSuffix(v.(string), suffix) {
+			return truthy(fmt.Sprintf("\nValue should have suffix = %s", suffix))
+		}
+		return falsy(fmt.Sprintf("\nValue should not have suffix = %s", suffix))
 	}
 }

--- a/fs_builder/builder.go
+++ b/fs_builder/builder.go
@@ -1,0 +1,165 @@
+package fsbuilder
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+type Common interface {
+	Parent() D
+	Root() D
+	Remove()
+	Name() string
+}
+
+type D interface {
+	Common
+	Dir(name string, perm os.FileMode) D
+	File(name string, flag int, perm os.FileMode) F
+	RemoveAll()
+}
+
+type F interface {
+	Common
+	Write(content []byte) F
+	WriteString(content string) F
+	WriteStringDedent(content string) F
+}
+
+func TmpDir(dir, pattern string) D {
+	name, err := ioutil.TempDir(dir, pattern)
+	if err != nil {
+		panic(err)
+	}
+	return &dirBuilder{name: name, parent: nil}
+}
+
+type dirBuilder struct {
+	name   string
+	parent D
+}
+
+func (d *dirBuilder) Name() string {
+	return d.name
+}
+
+func (d *dirBuilder) Root() D {
+	if d.parent == nil {
+		return d
+	}
+	return d.parent.Root()
+}
+
+func (d *dirBuilder) Remove() {
+	err := os.Remove(d.name)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (d *dirBuilder) RemoveAll() {
+	err := os.RemoveAll(d.name)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (d *dirBuilder) Dir(name string, perm os.FileMode) D {
+	name = filepath.Join(d.Name(), name)
+	err := os.Mkdir(name, perm)
+	if err != nil {
+		panic(err)
+	}
+	return &dirBuilder{name: name, parent: d}
+}
+
+func (d *dirBuilder) File(name string, flag int, perm os.FileMode) F {
+	name = filepath.Join(d.Name(), name)
+	f, err := os.OpenFile(name, flag, perm)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	return &fileBuilder{name: name, parent: d}
+}
+
+func (d *dirBuilder) Parent() D {
+	return d.parent
+}
+
+type fileBuilder struct {
+	name   string
+	parent D
+}
+
+func (f *fileBuilder) Name() string {
+	return f.name
+}
+
+func (f *fileBuilder) Root() D {
+	return f.Parent().Root()
+}
+
+func (f *fileBuilder) Remove() {
+	err := os.Remove(f.Name())
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (f *fileBuilder) Parent() D {
+	return f.parent
+}
+
+func (f *fileBuilder) Write(content []byte) F {
+	err := ioutil.WriteFile(f.name, content, 0600)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+func (f *fileBuilder) WriteString(content string) F {
+	return f.Write([]byte(content))
+}
+
+var prefixSpacesRegexp = regexp.MustCompile(`(?m)(^[ \t]*)(?:[^ \t\n])`)
+
+func (f *fileBuilder) WriteStringDedent(content string) F {
+	prefixSpaces := ""
+
+	prefixes := prefixSpacesRegexp.FindAllStringSubmatch(content, -1)
+
+l:
+	for i, p := range prefixes {
+		switch {
+		case i == 0:
+			prefixSpaces = p[1]
+		case strings.HasPrefix(p[1], prefixSpaces):
+			// current is prefixed by selected prefix
+			continue
+		case strings.HasPrefix(prefixSpaces, p[1]):
+			// current is a shorter common prefix
+			prefixSpaces = p[1]
+		default:
+			// no common prefix
+			prefixSpaces = ""
+			break l
+		}
+	}
+
+	if prefixSpaces != "" {
+		content = regexp.MustCompile(fmt.Sprintf("(?m)^%s", prefixSpaces)).ReplaceAllString(content, "")
+	}
+
+	return f.WriteString(content)
+}

--- a/fs_builder/builder_test.go
+++ b/fs_builder/builder_test.go
@@ -1,0 +1,201 @@
+package fsbuilder_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/elethoughts-code/goasserts/assertion"
+	fsBuilder "github.com/elethoughts-code/goasserts/fs_builder"
+)
+
+func Test_should_create_multiple_folder_hierarchy(t *testing.T) {
+	assert := assertion.New(t)
+
+	tmp := fsBuilder.TmpDir("", ".")
+	tmp.Dir("d1", 0600).Dir("d2", 0600).Dir("d31", 0600).Parent().Dir("d32", 0600)
+
+	assert.That(filepath.Join(tmp.Name(), "d1")).FileExists()
+	assert.That(filepath.Join(tmp.Name(), "d1", "d2")).FileExists()
+	assert.That(filepath.Join(tmp.Name(), "d1", "d2", "d31")).FileExists()
+	assert.That(filepath.Join(tmp.Name(), "d1", "d2", "d32")).FileExists()
+}
+
+func Test_Builder_should_make_tmp_folders_and_files(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+	subFolder1 := tmpFolder.Dir("my_sub_folder", 0600)
+
+	file1 := tmpFolder.File("my_file_1", os.O_CREATE, 0600)
+	file2 := subFolder1.File("my_file_2", os.O_CREATE, 0600)
+
+	file2.Write([]byte("Hello world !"))
+
+	// Then
+	assert.That(tmpFolder.Name()).HasPrefix(filepath.Join(os.TempDir(), "my_folder_1"))
+	assert.That(subFolder1.Name()).IsEq(filepath.Join(tmpFolder.Name(), "my_sub_folder"))
+	assert.That(file1.Name()).IsEq(filepath.Join(tmpFolder.Name(), "my_file_1"))
+	assert.That(file2.Name()).IsEq(filepath.Join(subFolder1.Name(), "my_file_2"))
+
+	f2Content, err := ioutil.ReadFile(file2.Name())
+	assert.That(err).IsNil()
+	assert.That(string(f2Content)).IsEq("Hello world !")
+
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+func Test_Builder_should_write_file_dedent(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+	file1 := tmpFolder.
+		File("my_file_1", os.O_CREATE, 0600).
+		WriteStringDedent(`
+						a:
+						  b: some text
+						  c: [1,2,3]
+						  d:
+						    - 1
+						    - 2`)
+	// Then
+	content, err := ioutil.ReadFile(file1.Name())
+	assert.That(err).IsNil()
+	assert.That(string(content)).IsEq(`
+a:
+  b: some text
+  c: [1,2,3]
+  d:
+    - 1
+    - 2`)
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+func Test_Builder_should_write_file_dedent_2(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+	file1 := tmpFolder.
+		File("my_file_1", os.O_CREATE, 0600).
+		WriteStringDedent(`
+						a:
+						  b: some text
+					c: [1,2,3]
+						  d:
+						    - 1
+						    - 2`)
+	// Then
+	content, err := ioutil.ReadFile(file1.Name())
+	assert.That(err).IsNil()
+	assert.That(string(content)).IsEq(`
+	a:
+	  b: some text
+c: [1,2,3]
+	  d:
+	    - 1
+	    - 2`)
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+func Test_Builder_should_not_dedent_when_no_consistent_leading_spaces(t *testing.T) {
+	assert := assertion.New(t)
+
+	// When
+	tmpFolder := fsBuilder.TmpDir("", "my_folder_1")
+	file1 := tmpFolder.
+		File("my_file_1", os.O_CREATE, 0600).
+		WriteStringDedent(`
+							a:
+						  b: some text
+                          c: [1,2,3]
+						  d: # there are spaces and not tabs
+						    - 1
+						    - 2`)
+	// Then
+	content, err := ioutil.ReadFile(file1.Name())
+	assert.That(err).IsNil()
+	assert.That(string(content)).IsEq(`
+							a:
+						  b: some text
+                          c: [1,2,3]
+						  d: # there are spaces and not tabs
+						    - 1
+						    - 2`)
+	// Clean up
+	t.Cleanup(tmpFolder.Root().RemoveAll)
+}
+
+func Test_TmpDir_should_panic_when_trying_to_create_folder_into_non_existing_one(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+	fsBuilder.TmpDir("/not_here", "my_folder_1")
+}
+
+func Test_Remove_should_panic_when_already_removed_folder(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+	tmp := fsBuilder.TmpDir("", "my_folder_1")
+	tmp.Remove()
+	tmp.Remove()
+}
+
+func Test_Remove_should_panic_when_already_removed_file(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+	tmp := fsBuilder.TmpDir("", "my_folder_1")
+	file := tmp.File("my_file", os.O_CREATE, 0600)
+	file.Remove()
+	file.Remove()
+
+	t.Cleanup(tmp.RemoveAll)
+}
+
+func Test_Dir_should_panic_when_already_created(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrExist)
+	}()
+	tmp := fsBuilder.TmpDir("", "folder")
+	tmp.File("my_dir", os.O_CREATE, 0600).Parent().Dir("my_dir", 0600)
+	t.Cleanup(tmp.RemoveAll)
+}
+
+func Test_File_should_panic_when_not_creating_and_non_existing_file(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+	tmp := fsBuilder.TmpDir("", "folder")
+	tmp.File("my_file", os.O_RDONLY, 0600)
+	t.Cleanup(tmp.RemoveAll)
+}
+
+func Test_File_should_panic_when_writing_to_removed_file(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		assert.That(r).IsError(os.ErrNotExist)
+	}()
+	tmp := fsBuilder.TmpDir("", "folder")
+	f := tmp.File("my_file", os.O_CREATE, 0600)
+	tmp.RemoveAll()
+	f.WriteString("abc")
+}

--- a/fs_builder/builder_unexported_test.go
+++ b/fs_builder/builder_unexported_test.go
@@ -1,0 +1,22 @@
+package fsbuilder //nolint: testpackage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/elethoughts-code/goasserts/assertion"
+)
+
+func Test_RemoveAll_should_panic(t *testing.T) {
+	assert := assertion.New(t)
+	defer func() {
+		r := recover()
+		err := &os.PathError{}
+		assert.That(r).AsError(&err)
+	}()
+	dir := dirBuilder{
+		name:   ".",
+		parent: nil,
+	}
+	dir.RemoveAll()
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/elethoughts-code/goasserts
 
 go 1.15
 
-require github.com/golang/mock v1.4.4
+require (
+	github.com/golang/mock v1.4.4
+	gopkg.in/yaml.v2 v2.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -9,3 +9,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
- FsExpectation	For file system related expectations (for now only FileExists)
- FsTransformer For file content reading (strings, json and yaml)
- ReflectTransformer For pointer dereferencing (useful when reading json or yaml into a pointer)
- String has prefix and suffix matchers
- Fluent API for tmp file hierarchy building and writing